### PR TITLE
Fixed About Us Redirect

### DIFF
--- a/en_ID/navigation.md
+++ b/en_ID/navigation.md
@@ -38,7 +38,7 @@
   - - - -
   * [**Members**](pages/interns.md)
 
-[About](https://kulkul.tech/about/)
+[About](https://www.kulkul.tech/about-us/)
 
 [Social]()
 


### PR DESCRIPTION
To solve: #145 

Web preview link: https://raw.githack.com/AlfredPros/open-source/about-us-fix/index.html
When clicking the "About" button on navigation bar, it will redirects to the right webpage.