### PR TITLE
Adding github logo to wiki homepage

### DIFF
--- a/en_ID/index.md
+++ b/en_ID/index.md
@@ -18,3 +18,7 @@ We're running our year-long internship program. If you're interested please reac
 - [tinyurl-client](https://github.com/kulkultech/tinyurl-client) - A Library to use TinyURL API in the Browser.
 - [bitly-client](https://github.com/kulkultech/bitly-client) - A Library to use BitLy API in the Browser.
 - [jumpstart-swe](https://github.com/kulkultech/jumpstart-swe) - A project to help aspiring software engineers to thrive.
+
+[![Fork Me On Github](https://i.postimg.cc/C1GWr36N/forkme-right-red-aa0000.png)](https://github.com/kulkultech/open-source)
+[Fork On Github](https://github.com/kulkultech/open-source)
+

--- a/en_ID/navigation.md
+++ b/en_ID/navigation.md
@@ -50,7 +50,12 @@
   * [<img src="pages/images/twitter.png" alt="alt text" width="20px"/> Twitter](https://twitter.com/kulkultech)
   * [<img src="pages/images/youtube.png" alt="alt text" width="20px"/> Youtube](https://www.youtube.com/channel/UCkafa38JOKqTfZmBaMYoywQ)
 
+
+<!--
+
 [gimmick:ForkMeOnGitHub (position: 'right', color: 'darkblue') ](https://github.com/kulkultech/open-source)
+-->
+[Fork On Github](https://github.com/kulkultech/open-source)
 
 <!-- A more complex navigation example: ----------------------------------------
 


### PR DESCRIPTION
Added the github logo and changed placement for fork on github text. Logo may need to be repositioned further as it is not centered.

Issue #156 