### PR TITLE
Github Logo Added To Navigation In Upper Right Corner

### DIFF
--- a/en_ID/index.html
+++ b/en_ID/index.html
@@ -198,6 +198,9 @@
 
 </head>
 <body>
+    <a class="forkmeongithub" href="https://github.com/kulkultech/open-source">
+    <img style="position: fixed;top: 10px;right: 11px;border: 0px;z-index: 2000;" src="https://i.postimg.cc/C1GWr36N/forkme-right-red-aa0000.png" alt="Fork me on Github">
+    </a>
     <noscript>
         This website requires Javascript to be enabled. Please turn on Javascript
         and reload the page.

--- a/en_ID/index.md
+++ b/en_ID/index.md
@@ -18,3 +18,10 @@ We're running our year-long internship program. If you're interested please reac
 - [tinyurl-client](https://github.com/kulkultech/tinyurl-client) - A Library to use TinyURL API in the Browser.
 - [bitly-client](https://github.com/kulkultech/bitly-client) - A Library to use BitLy API in the Browser.
 - [jumpstart-swe](https://github.com/kulkultech/jumpstart-swe) - A project to help aspiring software engineers to thrive.
+
+
+
+------
+
+[Contact Us](https://discord.com/invite/AYvyGpb7aP)
+

--- a/en_ID/index.md
+++ b/en_ID/index.md
@@ -2,7 +2,7 @@
 
 ## ![This is a alt text.](https://img.icons8.com/material-rounded/25/000000/enter-2.png "Welcome") Welcome
 
-Welcome! You're on Kulkul's open-source program page. We are committed to the open-source movement and using the open-source program as a tool to nurture and groom the next generation of Kul software engineers. We have internships and open-source programs that we started to open in late 2020. Browse around to learn more.
+Welcome! You're on Kulkul's open-source program page. We are committed to the open-source movement and using the open-source program as a tool to nurture and groom the next generation of Kul software engineers. We have [internships](pages/internship.md) and open-source programs that we started to open in late 2020. Browse around to learn more.
 
 ## ![This is a alt text.](https://img.icons8.com/ios-filled/25/000000/info.png "About") About Kulkul.tech
 

--- a/en_ID/navigation.md
+++ b/en_ID/navigation.md
@@ -50,8 +50,10 @@
   * [<img src="pages/images/twitter.png" alt="alt text" width="20px"/> Twitter](https://twitter.com/kulkultech)
   * [<img src="pages/images/youtube.png" alt="alt text" width="20px"/> Youtube](https://www.youtube.com/channel/UCkafa38JOKqTfZmBaMYoywQ)
 
-[gimmick:ForkMeOnGitHub (position: 'right', color: 'darkblue') ](https://github.com/kulkultech/open-source)
 
+<!--
+[gimmick:ForkMeOnGitHub (position: 'right', color: 'darkblue') ](https://github.com/kulkultech/open-source)
+-->
 <!-- A more complex navigation example: ----------------------------------------
 
 [Menu Item 1]()

--- a/en_ID/navigation.md
+++ b/en_ID/navigation.md
@@ -38,7 +38,7 @@
   - - - -
   * [**Members**](pages/interns.md)
 
-[About](https://kulkul.tech/about/)
+[About](https://www.kulkul.tech/about-us/)
 
 [Social]()
 


### PR DESCRIPTION
Error on wiki homepage fixed, link to github photo updated using gimmick. "Fork Me On Github" is not displayed however. I am do not know why this is the case.

Issue #161 
Preview link: https://raw.githack.com/cjj20/open-source/feature/newgitlogoadd/en_ID/index.html#!index.md